### PR TITLE
Add detached tabs

### DIFF
--- a/configurable-radiation-testsuite.pro
+++ b/configurable-radiation-testsuite.pro
@@ -54,6 +54,7 @@ SOURCES += \
     src/Tabs/OSCTab.cpp \
     src/Tabs/PSUTab.cpp \
     src/mainwindow.cpp \
+    src/detachedwindow.cpp \
     src/Configuration/ConfigElement.cpp \
     src/Configuration/ConfigManager.cpp \
     src/SubWindow/SubWindow.cpp \
@@ -90,6 +91,7 @@ HEADERS += \
     src/Tabs/OSCTab.h \
     src/Tabs/PSUTab.h \
     src/mainwindow.h \
+    src/detachedwindow.h \
     src/Configuration/ConfigElement.h \
     src/Configuration/ConfigManager.h \
     src/SubWindow/SubWindow.h \

--- a/src/detachedwindow.cpp
+++ b/src/detachedwindow.cpp
@@ -1,0 +1,20 @@
+#include "detachedwindow.h"
+
+#include <QTabWidget>
+
+DetachedWindow::DetachedWindow(QTabWidget *tabwidget, QWidget *child, QString title)
+{
+    mtabwidget = tabwidget;
+
+    setWindowTitle(title);
+    setGeometry(child->frameGeometry());
+    setCentralWidget(child);
+    child->show();
+}
+
+DetachedWindow::~DetachedWindow() {}
+
+void DetachedWindow::closeEvent(QCloseEvent *event) {
+
+    mtabwidget->addTab(centralWidget(), windowTitle());
+}

--- a/src/detachedwindow.h
+++ b/src/detachedwindow.h
@@ -1,0 +1,29 @@
+#ifndef DETACHEDWINDOW_H
+#define DETACHEDWINDOW_H
+
+/*
+ * Author: Ferdinand Stehle
+ *
+ * DetachedWindow for detached tabs
+ *
+ */
+
+#include <QMainWindow>
+
+class QTabWidget;
+
+class DetachedWindow : public QMainWindow
+{
+Q_OBJECT
+
+public:
+    DetachedWindow(QTabWidget *tabwidget, QWidget *child, QString title);
+    virtual ~DetachedWindow();
+
+private:
+    QTabWidget *mtabwidget;
+    void closeEvent(QCloseEvent *event) override;
+
+};
+
+#endif // DETACHEDWINDOW_H

--- a/src/mainlayout.cpp
+++ b/src/mainlayout.cpp
@@ -2,6 +2,7 @@
 
 #include "src/Configuration/ConfigManager.h"
 
+#include "detachedwindow.h"
 #include "Tabs/LBJTab.h"
 #include "Tabs/PSUTab.h"
 #include "Tabs/OSCTab.h"
@@ -74,6 +75,9 @@ QToolBar* MainLayout::create_toolbar()
     toolbar->setToolButtonStyle(Qt::ToolButtonTextBesideIcon);
     toolbar->setIconSize(QSize(16, 16));
 
+    detachTestButton = toolbar->addAction("Detach");
+    connect(detachTestButton, SIGNAL(triggered()), this, SLOT(detach_tab()));
+
     return toolbar;
 }
 
@@ -91,6 +95,15 @@ QTabWidget* MainLayout::create_window_tabs()
     windowTabs->addTab(new OSCTab(configManager, runManager), "OSC");
 
     return windowTabs;
+}
+
+void MainLayout::detach_tab(void)
+{
+    DetachedWindow *win = new DetachedWindow(windowTabs,
+                                windowTabs->currentWidget(),
+                                windowTabs->tabText(windowTabs->currentIndex()));
+
+    win->show();
 }
 
 // TODO Should be moved to seperate class

--- a/src/mainlayout.h
+++ b/src/mainlayout.h
@@ -31,6 +31,9 @@ public:
     MainLayout();
     virtual ~MainLayout();
 
+public slots:
+    void detach_tab();
+
 private slots:
     void set_start_button(enum RunMode mode);
     void set_stop_button(enum RunMode mode);
@@ -45,6 +48,7 @@ private:
 
     QAction* startTestButton;
     QAction* stopTestButton;
+    QAction* detachTestButton;
 
     void create_layout();
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2,6 +2,10 @@
 
 #include "mainlayout.h"
 
+#include <QApplication>
+#include <QCloseEvent>
+#include <QMessageBox>
+
 MainWindow::MainWindow()
 {
     create_layout();
@@ -18,3 +22,13 @@ void MainWindow::create_layout()
     setCentralWidget(new MainLayout);
 }
 
+void MainWindow::closeEvent(QCloseEvent *event) {
+    QMessageBox::StandardButton reply;
+    reply = QMessageBox::question(this, "Quit", "Do you really want to quit?",
+                                    QMessageBox::Yes | QMessageBox::No);
+    if (reply == QMessageBox::Yes) {
+        QApplication::quit();
+    } else {
+        event->ignore();
+    }
+}

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -21,7 +21,7 @@ public:
 
 private:
     void create_layout();
-
+    void closeEvent(QCloseEvent *event) override;
 };
 
 #endif // MAINWINDOW_H


### PR DESCRIPTION
Adds a button to detach a tab into its own window. When closing the window, the tab gets re-attached on the main window.

Additionaly, a quit confirmation dialog for the main window has been added.